### PR TITLE
Feature Request: Support for Docker Subdomains in YAML Manifests

### DIFF
--- a/api/v1alpha1/secretrotator_types.go
+++ b/api/v1alpha1/secretrotator_types.go
@@ -63,6 +63,9 @@ type SecretRotatorSpec struct {
 	// ArtifactoryUrl, URL of Artifactory
 	ArtifactoryUrl string `json:"artifactoryUrl,omitempty"`
 
+	// Other Artifactory subdomains, useful for users who use subdomains to separte out Docker repositories in Artifactory
+	ArtifactorySubdomains []string `json:"artifactorySubdomains,omitempty"`
+
 	// Each target user's ServiceAccount, restricting access to only the specified service accounts and ensuring the role is limited to the jfrog operator service account.
 	ServiceAccount ServiceAccountDetails `json:"serviceAccount,omitempty"`
 

--- a/api/v1alpha1/secretrotator_types.go
+++ b/api/v1alpha1/secretrotator_types.go
@@ -63,7 +63,7 @@ type SecretRotatorSpec struct {
 	// ArtifactoryUrl, URL of Artifactory
 	ArtifactoryUrl string `json:"artifactoryUrl,omitempty"`
 
-	// Other Artifactory subdomains, useful for users who use subdomains to separte out Docker repositories in Artifactory
+	// ArtifactorySubdomains holds a list of Artifactory subdomain names.
 	ArtifactorySubdomains []string `json:"artifactorySubdomains,omitempty"`
 
 	// Each target user's ServiceAccount, restricting access to only the specified service accounts and ensuring the role is limited to the jfrog operator service account.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -153,6 +153,11 @@ func (in *SecretRotatorSpec) DeepCopyInto(out *SecretRotatorSpec) {
 		copy(*out, *in)
 	}
 	in.NamespaceSelector.DeepCopyInto(&out.NamespaceSelector)
+	if in.ArtifactorySubdomains != nil {
+		in, out := &in.ArtifactorySubdomains, &out.ArtifactorySubdomains
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	out.ServiceAccount = in.ServiceAccount
 	if in.RefreshInterval != nil {
 		in, out := &in.RefreshInterval, &out.RefreshInterval

--- a/charts/jfrog-registry-operator/examples/secretrotator.yaml
+++ b/charts/jfrog-registry-operator/examples/secretrotator.yaml
@@ -17,6 +17,7 @@ spec:
     # - secretName: token-generic-secret
     #   secretType: generic
   artifactoryUrl: ""
+  artifactorySubdomains: []
   refreshTime: 30m
   secretMetadata:
     annotations:

--- a/config/samples/jfrog_v1alpha1_secretrotator.yaml
+++ b/config/samples/jfrog_v1alpha1_secretrotator.yaml
@@ -17,6 +17,7 @@ spec:
   # - secretName: token-generic-secret
   #   secretType: generic
   artifactoryUrl: ""
+  artifactorySubdomains: []
   refreshTime: 30m
   secretMetadata:
     annotations:

--- a/config/samples/jfrog_v1alpha1_secretrotator2.yaml
+++ b/config/samples/jfrog_v1alpha1_secretrotator2.yaml
@@ -17,6 +17,7 @@ spec:
   # - secretName: token-generic-secret
   #   secretType: generic
   artifactoryUrl: ""
+  artifactorySubdomains: []
   refreshTime: 10m
   secretMetadata:
     annotations:

--- a/internal/resource/secret.go
+++ b/internal/resource/secret.go
@@ -73,6 +73,34 @@ func getRemovedNamespaces(currentNSs v1.NamespaceList, provisionedNSs []string) 
 	return removedNSs
 }
 
+//generateDockerConfigJSON creates a valid dockerconfig.json structure with the provided token and returns it as a byte slice
+func generateDockerConfigJSON(tokenb64 string, secretRotator *jfrogv1alpha1.SecretRotator) ([]byte, error) {
+	auths := make(map[string]map[string]string)
+
+	// Add the secretRotator.Spec.ArtifactoryUrl first
+	auths[secretRotator.Spec.ArtifactoryUrl] = map[string]string{
+		"auth": tokenb64,
+	}
+
+	//Add the secretRotator.Spec.ArtifactorySubdomains
+	for _, url := range secretRotator.Spec.ArtifactorySubdomains {
+		auths[url] = map[string]string{
+			"auth": tokenb64,
+		}
+	}
+
+	dockerConfig := map[string]interface{}{
+		"auths": auths,
+	}
+
+	dockerConfigBytes, err := json.Marshal(dockerConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal docker config %w", err)
+	}
+
+	return dockerConfigBytes, nil
+}
+
 // DeleteSecret deletes a specific secret if it is owned by the SecretRotator.
 func DeleteSecret(ctx context.Context, secretName, secretRotatorName, namespace, secretType string, k8sClient client.Client) error {
 	existingSecret, err := GetSecret(ctx, namespace, secretName, k8sClient)
@@ -132,27 +160,9 @@ func CreateOrUpdateSecrets(req controller.Request, ctx context.Context, tokenDet
 		auth := fmt.Sprintf("%s:%s", tokenDetails.Username, tokenDetails.Token)
 		tokenb64 := base64.StdEncoding.EncodeToString([]byte(auth))
 
-		auths := make(map[string]map[string]string)
-
-		// Add the secretRotator.Spec.ArtifactoryUrl first
-		auths[secretRotator.Spec.ArtifactoryUrl] = map[string]string{
-			"auth": tokenb64,
-		}
-
-		//Add the secretRotator.Spec.ArtifactorySubdomains
-		for _, url := range secretRotator.Spec.ArtifactorySubdomains {
-			auths[url] = map[string]string{
-				"auth": tokenb64,
-			}
-		}
-
-		dockerConfig := map[string]interface{}{
-			"auths": auths,
-		}
-
-		dockerConfigBytes, err := json.Marshal(dockerConfig)
+		dockerConfigBytes, err := generateDockerConfigJSON(tokenb64, secretRotator)
 		if err != nil {
-			return fmt.Errorf("failed to marshal docker config %w", err)
+			return err
 		}
 
 		secretObj.Data = map[string][]byte{


### PR DESCRIPTION
We use Artifactory to host a large number of Docker images, and we separate repositories by environment (e.g., dev, uat, prod) using subdomains such as:

* `docker.artifactory.company.com`
* `docker-local.artifactory.company.com`
* `base-images.artifactory.company.com`

Currently, we manage and update Docker registry credentials across all our EKS clusters using the External Secrets Operator, which allows our pods to pull images securely from Artifactory.

After discovering this operator, we tried it out and found it very effective. However, we encountered a limitation. We had to apply a separate YAML manifest for each Docker subdomain. With over 20 repositories in Artifactory, this quickly becomes cumbersome.

This pull request introduces a feature that allows users to define multiple Artifactory subdomains within a single manifest. The controller will then generate a `dockerconfig.json` Kubernetes secret containing all the specified subdomains in the correct format.

Example configuration in `secretrotator.yaml`:

```yaml
artifactoryUrl: "https://artifactory.company.com"
artifactorySubdomains:
  - "https://docker.artifactory.company.com"
  - "https://base-images.artifactory.company.com"
```

I'm not sure if you currently accept external contributions, but this feature would significantly reduce the manual effort involved in our deployments. Please let me know if any changes are required.

Thank you!
