### PR TITLE
Upgrade golang.org/x/oauth2 to v0.27.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/net v0.23.0 // indirect
-	golang.org/x/oauth2 v0.11.0 // indirect
+	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/term v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect


### PR DESCRIPTION
Updated golang.org/x/oauth2 to version v0.27.0.

- Fixing vulnerability https://github.com/advisories/GHSA-6v2p-p543-phr9

