### PR TITLE
Change PR event from target to regular pull_request

### DIFF
--- a/.github/workflows/validate-pr-target-branch.yml
+++ b/.github/workflows/validate-pr-target-branch.yml
@@ -1,7 +1,7 @@
 name: Validate Pull Request Target Branch
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened


### PR DESCRIPTION
Change pull_request_target to pull_request in workflow No credentials are required. There is no justification for running this in a trusted context.

- [ ] All [tests](https://github.com/jfrog/jfrog-registry-operator#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the main branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
---

